### PR TITLE
Modifies field validation macro to allow nil currency parameter

### DIFF
--- a/mobile/ios/Classes/AnalyticsGoogleTrackerProxy.m
+++ b/mobile/ios/Classes/AnalyticsGoogleTrackerProxy.m
@@ -212,7 +212,7 @@
     ENSURE_ARG_OR_NIL_FOR_KEY(category, args, @"category", NSString);
     ENSURE_ARG_FOR_KEY(price, args, @"price", NSNumber);
     ENSURE_ARG_FOR_KEY(quantity, args, @"quantity", NSNumber);
-    ENSURE_ARG_FOR_KEY(currency, args, @"currency", NSString);
+    ENSURE_ARG_OR_NIL_FOR_KEY(currency, args, @"currency", NSString);
 
     GAIDictionaryBuilder *builder = [GAIDictionaryBuilder createItemWithTransactionId:transactionId
                                                                                  name:name


### PR DESCRIPTION
I noticed while looking at the source for `tracker.trackTransactionItem`, that the "currency" parameter is not using the same macro as in `tracker.trackTransaction` to ensure the field's value. I changed the macro it was using to make it consistent with the documentation in the readme file and the `tracker.trackTransaction` call.
