### PR TITLE
Corrects module API version

### DIFF
--- a/mobile/android/manifest
+++ b/mobile/android/manifest
@@ -3,7 +3,7 @@
 # during compilation, packaging, distribution, etc.
 #
 version: 2.1.0
-apiversion: 3
+apiversion: 2
 description: Google Analytics for Android v4
 author: Matt Tuttle
 license: MIT


### PR DESCRIPTION
After talking with the guys at Appcelerator, they confirmed that this version number should be set to '2'. This fixes issue #3.
