### PR TITLE
performing startup and shutdown methods regardless of current thread

### DIFF
--- a/ios/Classes/AnalyticsGoogleModule.m
+++ b/ios/Classes/AnalyticsGoogleModule.m
@@ -40,6 +40,10 @@
             dryRun = [[GAI sharedInstance] dryRun];
             dispatchInterval = [[GAI sharedInstance] dispatchInterval];
         }, NO);
+    } else {
+            optOut = [[GAI sharedInstance] optOut];
+            dryRun = [[GAI sharedInstance] dryRun];
+            dispatchInterval = [[GAI sharedInstance] dispatchInterval];
     }
 }
 
@@ -53,6 +57,8 @@
         TiThreadPerformOnMainThread(^{
             [[GAI sharedInstance] dispatch];
         }, NO);
+    } else {
+        [[GAI sharedInstance] dispatch];
     }
 }
 


### PR DESCRIPTION
This was causing a hard to find, hard to replicate, almost race condition of sorts. The methods weren't getting called upon startup, and the app was crashing as a result. I added the same check to shutdown for solidarity.