### PR TITLE
Added support for manual dispatching of events.

### DIFF
--- a/ios/Classes/AnalyticsGoogleTrackerProxy.m
+++ b/ios/Classes/AnalyticsGoogleTrackerProxy.m
@@ -242,6 +242,13 @@
         createExceptionWithDescription: description  withFatal: fatal] build]];
 }
 
+// Allow for manual dispatching of events when dispatchInterval is set to 0
+-(void)dispatchAnalyticsEvents:(id)args
+{
+    ENSURE_UI_THREAD_0_ARGS;
+    [[GAI sharedInstance] dispatch];
+}
+
 -(id)trackingId
 {
     return trackingId;


### PR DESCRIPTION
Google analytics has the ability for you to turn off the dispatchInterval by setting it to 0. This in turn requires the user to call [[GAI sharedInstance] dispatch]; to send the events to google. In our implementation we only send the events out when there is no other network activity happening. Adding this function to the proxy object allows us to control when the events are sent.