### PR TITLE
Update manifest to build against Titanium SDK 6+

### DIFF
--- a/android/manifest
+++ b/android/manifest
@@ -2,9 +2,9 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 3.1.0
-apiversion: 2
-architectures: armeabi armeabi-v7a x86
+version: 4.0.0
+apiversion: 3
+architectures: armeabi-v7a x86
 description: Google Analytics for Titanium Appcelerator
 author: Matt Tuttle
 license: MIT
@@ -16,4 +16,4 @@ name: analytics.google
 moduleid: analytics.google
 guid: 6bdae9d9-4154-4d21-aacf-c0f95b193dae
 platform: android
-minsdk: 3.4.2
+minsdk: 6.0.0


### PR DESCRIPTION
Builds against Titanium 6.0.0+ and V8 5.1.289.59.

Needs to be built against a master/6.0.0 build of the SDK:
```
appc ti sdk install -b master
# edit your build.properties
ant
```